### PR TITLE
Chande swap test account to Charlie

### DIFF
--- a/integration-test-suite/tests/evmToNativeSwap.test.ts
+++ b/integration-test-suite/tests/evmToNativeSwap.test.ts
@@ -34,7 +34,7 @@ describe("Swap EVM tokens to Native tokens test", function () {
     const addressString = web3.utils.bytesToHex(aliceEthAccount);
     // @ts-ignore
     let {data: aliceBalanceBefore} =  await polkadotApi.query.system.account(alice.address);
-   
+
     //Create a extrinsic, withdraw 10 5ire coin from Alice
     const amount = polkadotApi.createType("Balance", "10000000000000000000");
     const transaction = await polkadotApi.tx.evm.withdraw(aliceEthAccount, amount);

--- a/integration-test-suite/tests/swapNativetoEvm.test.ts
+++ b/integration-test-suite/tests/swapNativetoEvm.test.ts
@@ -8,10 +8,10 @@ import { Web3 } from "web3";
 
 // Setup the API and Alice Account
 async function init() {
-  const bob = keyring.addFromUri("//Bob", { name: "Alice default" });
+  const charlie = keyring.addFromUri("//Charlie", { name: "Charlie default" });
 
-  const bobEthAccount = addressToEvm(bob.addressRaw);
-  return { bob, bobEthAccount };
+  const charlieEthAccount = addressToEvm(charlie.addressRaw);
+  return { charlie, charlieEthAccount };
 }
 
 // Keyring needed to sign using Alice account
@@ -27,23 +27,23 @@ describe("Swap token tests", function () {
   });
 
   // Should swap native token to evm token
-  it("Swap native tokens to evm tokens ", async () => {
-    const { bob, bobEthAccount } = await init();
+  it.only("Swap native tokens to evm tokens ", async () => {
+    const { charlie, charlieEthAccount } = await init();
     const web3 = new Web3(
       new Web3.providers.HttpProvider("http://127.0.0.1:9933")
     );
-    const addressString = web3.utils.bytesToHex(bobEthAccount);
-    let bobBalance = await web3.eth.getBalance(addressString);
-    console.log("Balance:", bobBalance);
+    const addressString = web3.utils.bytesToHex(charlieEthAccount);
+    let charlieBalance = await web3.eth.getBalance(addressString);
+    console.log("Balance:", charlieBalance);
     let expectationBalance = web3.utils.toBigInt(0);
     //assert that bob initial evm balance is 0
-    expect(bobBalance).to.equal(expectationBalance);
+    expect(charlieBalance).to.equal(expectationBalance);
 
     //Create a extrinsic, transferring 10 5ire coin to Bob
     const amount = polkadotApi.createType("Balance", "10000000000000000000");
-    const transaction = polkadotApi.tx.evm.deposit(bobEthAccount, amount);
+    const transaction = polkadotApi.tx.evm.deposit(charlieEthAccount, amount);
 
-    const unsub = await transaction.signAndSend(bob, (result) => {
+    const unsub = await transaction.signAndSend(charlie, (result) => {
       console.log(`Swap is ${result.status}`);
       if (result.status.isInBlock) {
         console.log(`Swap included at blockHash ${result.status.asInBlock}`);
@@ -56,9 +56,9 @@ describe("Swap token tests", function () {
     });
 
     await waitForEvent(polkadotApi, "balances", "Transfer");
-    let bobBalanceAfter = await web3.eth.getBalance(addressString);
+    let charlieBalanceAfter = await web3.eth.getBalance(addressString);
     let expectationBalanceAfter = web3.utils.toBigInt("10000000000000000000");
-    expect(bobBalanceAfter).to.equal(expectationBalanceAfter);
+    expect(charlieBalanceAfter).to.equal(expectationBalanceAfter);
   });
 
   after(async () => {


### PR DESCRIPTION
Make use of Charlie instead of Bob to for native token to evm token test. This is because Bob's account has already been prefunded in the genesis chain spec