### PR TITLE
fix!: replace AccountId32 with AccountId20 in esg library to adopt unified address scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6020,6 +6020,8 @@ name = "pallet-esg"
 version = "1.0.0"
 dependencies = [
  "bs58 0.4.0",
+ "firechain-runtime-core-primitives",
+ "fp-account",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/frame/esg/Cargo.toml
+++ b/frame/esg/Cargo.toml
@@ -24,6 +24,8 @@ sp-runtime = { workspace = true, default-features = false }
 sp-core = { workspace = true, default-features = false }
 sp-io = { workspace = true, default-features = false }
 sp-std = { workspace = true, default-features = false }
+fp-account = {workspace=true, default-features = false}
+firechain-runtime-core-primitives = {workspace = true, default-features = false}
 
 [dev-dependencies]
 sp-runtime = { workspace = true, default-features = false}
@@ -33,6 +35,8 @@ default = ["std"]
 std = [
     "serde",
     "codec/std",
+    "firechain-runtime-core-primitives/std",
+    "fp-account/std",
     "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",


### PR DESCRIPTION
Summary:
This pull request addresses a significant change in the `esg` pallet by replacing AccountId32 with AccountId20 to align with the unified address scheme.
Details:

   Replaced `AccountId32` with `AccountId20` in `esg/src/lib.rs`.
   Updated relevant functions to support `AccountId20`.
Impact:

    This change may affect existing integrations relying on `AccountId32` within the esg pallet, for instance the staking pallet.
    Marked as a breaking change (!) to alert developers.
Testing:

    Tests are to be updated to reflect the change.
Review Notes:

    Verify the consistency and correctness of the changes.
    Check for any potential impact areas.
Acknowledgments:

    This change is part of the effort to adopt a unified address scheme.

