### PR TITLE
fix!: replace `AccountId32` with `AccountId20` in `esg` pallet to adopt unified address scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tmp
 .idea
 
 *.iml
+compile.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "firechain-qa-runtime"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "firechain-runtime-core-primitives",
  "fp-account",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6020,7 +6020,6 @@ name = "pallet-esg"
 version = "1.0.0"
 dependencies = [
  "bs58 0.4.0",
- "firechain-runtime-core-primitives",
  "fp-account",
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6020,6 +6020,8 @@ name = "pallet-esg"
 version = "1.0.0"
 dependencies = [
  "bs58 0.4.0",
+ "firechain-runtime-core-primitives",
+ "fp-account",
  "frame-benchmarking",
  "frame-support",
  "frame-system",

--- a/frame/esg/Cargo.toml
+++ b/frame/esg/Cargo.toml
@@ -25,7 +25,6 @@ sp-core = { workspace = true, default-features = false }
 sp-io = { workspace = true, default-features = false }
 sp-std = { workspace = true, default-features = false }
 fp-account = {workspace=true, default-features = false}
-firechain-runtime-core-primitives = {workspace = true, default-features = false}
 
 [dev-dependencies]
 sp-runtime = { workspace = true, default-features = false}
@@ -35,7 +34,6 @@ default = ["std"]
 std = [
     "serde",
     "codec/std",
-    "firechain-runtime-core-primitives/std",
     "fp-account/std",
     "frame-benchmarking/std",
     "frame-support/std",

--- a/frame/esg/Cargo.toml
+++ b/frame/esg/Cargo.toml
@@ -24,6 +24,8 @@ sp-runtime = { workspace = true, default-features = false }
 sp-core = { workspace = true, default-features = false }
 sp-io = { workspace = true, default-features = false }
 sp-std = { workspace = true, default-features = false }
+fp-account = {workspace=true, default-features = false}
+firechain-runtime-core-primitives = {workspace = true, default-features = false}
 
 [dev-dependencies]
 sp-runtime = { workspace = true, default-features = false}
@@ -33,6 +35,8 @@ default = ["std"]
 std = [
     "serde",
     "codec/std",
+    "firechain-runtime-core-primitives/std",
+    "fp-account/std",
     "frame-benchmarking/std",
     "frame-support/std",
     "frame-system/std",

--- a/frame/esg/src/lib.rs
+++ b/frame/esg/src/lib.rs
@@ -22,12 +22,15 @@ pub trait Sustainability<AccountId> {
 
 #[frame_support::pallet]
 pub mod pallet {
-	use frame_support::{
+	use fp_account::AccountId20;
+use frame_support::{
 		WeakBoundedVec,
 		pallet_prelude::{DispatchResult, *},
 	};
+	use sp_core::H160;
 	use sp_std::vec::Vec;
 	use serde_json::Value;
+	use core::str::FromStr;
 	use core::num::IntErrorKind;
 	use frame_system::pallet_prelude::*;
 	use crate::{traits::ERScoresTrait, weights::WeightInfo};
@@ -162,11 +165,13 @@ pub mod pallet {
 			if Self::not_valid_addr(acc.as_bytes()) {
 				return None
 			}
-			
-			match T::AccountId::decode(&mut acc[2..].as_ref()) {
-				Ok(id) => Some(id),
-				Err(_) => None,
-			}
+
+			H160::from_str(&acc[2..])
+			.map(Into::into)
+			.ok()
+			.and_then(|acc_id: AccountId20| {
+				T::AccountId::decode(&mut acc_id.as_ref()).ok()
+			})
 		}
 	}
 

--- a/frame/esg/src/mock.rs
+++ b/frame/esg/src/mock.rs
@@ -1,6 +1,9 @@
 //! Esg pallet tests.
 #![allow(dead_code)]
-use sp_core::H256;
+
+use core::str::FromStr;
+
+use fp_account::AccountId20;
 use sp_core::Decode;
 use crate as pallet_esg;
 use frame_system as system;
@@ -15,6 +18,10 @@ use frame_support::traits::{
 	ConstU16, 
 	ConstU32, 
 	ConstU64, 
+};
+use sp_core::{
+	H160, 
+	H256
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -68,5 +75,6 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 }
 
 pub fn hexstr2acc_id20(s: &str) -> <Test as frame_system::Config>::AccountId {
-	<Test as frame_system::Config>::AccountId::decode(&mut s.as_ref()).unwrap()
+	let acc_id: AccountId20 = H160::from_str(s).map(Into::into).ok().unwrap();
+	<Test as frame_system::Config>::AccountId::decode(&mut acc_id.as_ref()).unwrap()
 }

--- a/frame/esg/src/mock.rs
+++ b/frame/esg/src/mock.rs
@@ -1,7 +1,9 @@
 //! Esg pallet tests.
 #![allow(dead_code)]
 
+use bs58::decode;
 use sp_core::H256;
+use sp_core::Decode;
 use crate as pallet_esg;
 use frame_system as system;
 use fp_account::AccountId20;
@@ -15,7 +17,7 @@ use sp_runtime::{
 use frame_support::traits::{
 	ConstU16, 
 	ConstU32, 
-	ConstU64
+	ConstU64, IsType
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -64,8 +66,10 @@ impl pallet_esg::Config for Test {
 	type WeightInfo = ();
 }
 
-// Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	//system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
 	system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
+}
+
+pub fn hexstr2acc_id20(s: &str) -> <Test as frame_system::Config>::AccountId {
+	<Test as frame_system::Config>::AccountId::decode(&mut s.as_ref()).unwrap()
 }

--- a/frame/esg/src/mock.rs
+++ b/frame/esg/src/mock.rs
@@ -1,12 +1,9 @@
 //! Esg pallet tests.
 #![allow(dead_code)]
-
-use bs58::decode;
 use sp_core::H256;
 use sp_core::Decode;
 use crate as pallet_esg;
 use frame_system as system;
-use fp_account::AccountId20;
 use sp_runtime::{
 	BuildStorage,
 	traits::{
@@ -17,7 +14,7 @@ use sp_runtime::{
 use frame_support::traits::{
 	ConstU16, 
 	ConstU32, 
-	ConstU64, IsType
+	ConstU64, 
 };
 
 type Block = frame_system::mocking::MockBlock<Test>;
@@ -43,7 +40,7 @@ impl system::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
-	type AccountId = AccountId20;
+	type AccountId = fp_account::AccountId20;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = ConstU64<250>;

--- a/frame/esg/src/mock.rs
+++ b/frame/esg/src/mock.rs
@@ -1,16 +1,25 @@
 //! Esg pallet tests.
+#![allow(dead_code)]
 
-use crate as pallet_esg;
-use frame_support::traits::{ConstU16, ConstU32, ConstU64};
-use frame_system as system;
 use sp_core::H256;
+use crate as pallet_esg;
+use frame_system as system;
+use fp_account::AccountId20;
 use sp_runtime::{
-	testing::Header,
-	traits::{BlakeTwo256, IdentityLookup},
-	AccountId32, BuildStorage,
+	BuildStorage,
+	traits::{
+		BlakeTwo256, 
+		IdentityLookup
+	},
 };
-type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
+use frame_support::traits::{
+	ConstU16, 
+	ConstU32, 
+	ConstU64
+};
+
 type Block = frame_system::mocking::MockBlock<Test>;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 
 frame_support::construct_runtime!(
 	pub enum Test where
@@ -32,7 +41,7 @@ impl system::Config for Test {
 	type RuntimeCall = RuntimeCall;
 	type Hash = H256;
 	type Hashing = BlakeTwo256;
-	type AccountId = AccountId32;
+	type AccountId = AccountId20;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type RuntimeEvent = RuntimeEvent;
 	type BlockHashCount = ConstU64<250>;
@@ -54,15 +63,6 @@ impl pallet_esg::Config for Test {
 	type MaxFileSize = ConstU32<1024000>;
 	type WeightInfo = ();
 }
-
-pub const ROOT: AccountId32 = AccountId32::new([0u8; 32]);
-pub const SUDO_ORACLE: AccountId32 = AccountId32::new([0u8; 32]);
-pub const SUDO_ORACLE_2: AccountId32 = AccountId32::new([1u8; 32]);
-pub const NON_SUDO_ORACLE: AccountId32 = AccountId32::new([2u8; 32]);
-pub const NON_SUDO_ORACLE_2: AccountId32 = AccountId32::new([3u8; 32]);
-
-pub const ALICE: AccountId32 = AccountId32::new([4u8; 32]);
-pub const DUMMY_SUDO_ORACLE: AccountId32 = AccountId32::new([5u8; 32]);
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {

--- a/frame/esg/src/tests.rs
+++ b/frame/esg/src/tests.rs
@@ -1,65 +1,100 @@
+use fp_account::AccountId20;
+use sp_runtime::DispatchError;
 pub use crate::{mock::*, Error};
 use frame_support::{assert_noop, assert_ok, WeakBoundedVec};
-use sp_runtime::{AccountId32, DispatchError};
-use sp_std::str::FromStr;
 
 const MAX_ESG_SCORE: u16 = 100;
 
+#[allow(non_snake_case)]
+struct Addr {
+	ROOT: AccountId20,
+	ALICE: AccountId20,
+	SUDO_ORACLE: AccountId20,
+	SUDO_ORACLE_2: AccountId20,
+	NON_SUDO_ORACLE: AccountId20,
+	DUMMY_SUDO_ORACLE: AccountId20,
+	NON_SUDO_ORACLE_2: AccountId20,
+	NON_SUDO_ORACLE_6: AccountId20,
+	NON_SUDO_ORACLE_7: AccountId20,
+	NON_SUDO_ORACLE_8: AccountId20,
+	NON_SUDO_ORACLE_9: AccountId20,
+	NON_SUDO_ORACLE_10: AccountId20,
+}
+
+impl Default for Addr {
+	fn default() -> Self {
+		Self {
+			ROOT: AccountId20::from([0u8; 20]),
+			ALICE: AccountId20::from([4u8; 20]),
+			SUDO_ORACLE: AccountId20::from([0u8; 20]),
+			SUDO_ORACLE_2: AccountId20::from([1u8; 20]),
+			NON_SUDO_ORACLE: AccountId20::from([2u8; 20]),
+			DUMMY_SUDO_ORACLE: AccountId20::from([5u8; 20]),
+			NON_SUDO_ORACLE_2: AccountId20::from([3u8; 20]),
+			NON_SUDO_ORACLE_6: AccountId20::from([6u8; 20]),
+			NON_SUDO_ORACLE_7: AccountId20::from([7u8; 20]),
+			NON_SUDO_ORACLE_8: AccountId20::from([8u8; 20]),
+			NON_SUDO_ORACLE_9: AccountId20::from([9u8; 20]),
+			NON_SUDO_ORACLE_10: AccountId20::from([10u8; 20]),
+		}
+	}
+}
+
 #[test]
+#[allow(non_snake_case)]
 fn it_must_register_oracles_new() {
 	new_test_ext().execute_with(|| {
-		pub const NON_SUDO_ORACLE_6: AccountId32 = AccountId32::new([6u8; 32]);
-		pub const NON_SUDO_ORACLE_7: AccountId32 = AccountId32::new([7u8; 32]);
-		pub const NON_SUDO_ORACLE_8: AccountId32 = AccountId32::new([8u8; 32]);
-		pub const NON_SUDO_ORACLE_9: AccountId32 = AccountId32::new([9u8; 32]);
-		pub const NON_SUDO_ORACLE_10: AccountId32 = AccountId32::new([10u8; 32]);
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		let addr = Addr::default();
+		
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 		assert_ok!(Esg::register_an_oracle(
-			RuntimeOrigin::signed(SUDO_ORACLE),
-			NON_SUDO_ORACLE_6,
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
+			addr.NON_SUDO_ORACLE_6,
 			false
 		));
 		assert_ok!(Esg::register_an_oracle(
-			RuntimeOrigin::signed(SUDO_ORACLE),
-			NON_SUDO_ORACLE_8,
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
+			addr.NON_SUDO_ORACLE_8,
 			false
 		));
 		assert_ok!(Esg::register_an_oracle(
-			RuntimeOrigin::signed(SUDO_ORACLE),
-			NON_SUDO_ORACLE_9,
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
+			addr.NON_SUDO_ORACLE_9,
 			false
 		));
 		assert_ok!(Esg::register_an_oracle(
-			RuntimeOrigin::signed(SUDO_ORACLE),
-			NON_SUDO_ORACLE_10,
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
+			addr.NON_SUDO_ORACLE_10,
 			false
 		));
 		assert_ok!(Esg::register_an_oracle(
-			RuntimeOrigin::signed(SUDO_ORACLE),
-			NON_SUDO_ORACLE_7,
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
+			addr.NON_SUDO_ORACLE_7,
 			false
 		));
 
-		assert_ok!(Esg::deregister_an_oracle(RuntimeOrigin::root(), NON_SUDO_ORACLE_7, false));
+		assert_ok!(Esg::deregister_an_oracle(RuntimeOrigin::root(), addr.NON_SUDO_ORACLE_7, false));
 	});
 }
 
 #[test]
 fn it_must_register_oracles() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		System::set_block_number(1);
 		// registering a sudo oracle with root
 		// Check extrinsic should work for sudo oracle
 		// SUDO_ORACLE is sudo oracle which is assigned by Sudo key
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// Check sudo oracle
-		assert!(Esg::get_oracle_sudo().contains(&SUDO_ORACLE));
+		assert!(Esg::get_oracle_sudo().contains(&addr.SUDO_ORACLE));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
 		System::set_block_number(1);
@@ -67,48 +102,48 @@ fn it_must_register_oracles() {
 		// Check extrinsic should work for non sudo oracle
 		// due to sudo key -> NON_SUDO_ORACLE become SUDO ORACLE with false condition
 
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), NON_SUDO_ORACLE, false));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.NON_SUDO_ORACLE, false));
 
-		assert!(Esg::get_oracle_nsudo().contains(&NON_SUDO_ORACLE));
+		assert!(Esg::get_oracle_nsudo().contains(&addr.NON_SUDO_ORACLE));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: false,
-			oracle: NON_SUDO_ORACLE,
+			oracle: addr.NON_SUDO_ORACLE,
 		}));
 
 		System::set_block_number(1);
 
 		// Sudo oracle assign to new sudo oracle
 		assert_ok!(Esg::register_an_oracle(
-			RuntimeOrigin::signed(SUDO_ORACLE),
-			SUDO_ORACLE_2,
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
+			addr.SUDO_ORACLE_2,
 			true
 		));
 
-		assert!(Esg::get_oracle_sudo().contains(&SUDO_ORACLE_2));
+		assert!(Esg::get_oracle_sudo().contains(&addr.SUDO_ORACLE_2));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE_2,
+			oracle: addr.SUDO_ORACLE_2,
 		}));
 
 		System::set_block_number(1);
 
 		// Sudo oracle assign to another non sudo oracle
 		assert_ok!(Esg::register_an_oracle(
-			RuntimeOrigin::signed(SUDO_ORACLE),
-			NON_SUDO_ORACLE_2,
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
+			addr.NON_SUDO_ORACLE_2,
 			false
 		));
 
-		assert!(Esg::get_oracle_nsudo().contains(&NON_SUDO_ORACLE_2));
+		assert!(Esg::get_oracle_nsudo().contains(&addr.NON_SUDO_ORACLE_2));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: false,
-			oracle: NON_SUDO_ORACLE_2,
+			oracle: addr.NON_SUDO_ORACLE_2,
 		}));
 	});
 }
@@ -116,23 +151,25 @@ fn it_must_register_oracles() {
 #[test]
 fn it_must_fail_to_register_existent_oracle_again() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		System::set_block_number(1);
 		// registering a sudo oracle with root
 		// Check extrinsic should work for sudo oracle
 		// SUDO_ORACLE is sudo oracle which is assigned by Sudo key
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// Check sudo oracle
-		assert!(Esg::get_oracle_sudo().contains(&SUDO_ORACLE));
+		assert!(Esg::get_oracle_sudo().contains(&addr.SUDO_ORACLE));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
 		assert_noop!(
-			Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true),
+			Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true),
 			Error::<Test>::OracleRegisteredAlready
 		);
 
@@ -141,18 +178,18 @@ fn it_must_fail_to_register_existent_oracle_again() {
 		// Check extrinsic should work for non sudo oracle
 		// due to sudo key -> NON_SUDO_ORACLE become SUDO ORACLE with false condition
 
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), NON_SUDO_ORACLE, false));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.NON_SUDO_ORACLE, false));
 
-		assert!(Esg::get_oracle_nsudo().contains(&NON_SUDO_ORACLE));
+		assert!(Esg::get_oracle_nsudo().contains(&addr.NON_SUDO_ORACLE));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: false,
-			oracle: NON_SUDO_ORACLE,
+			oracle: addr.NON_SUDO_ORACLE,
 		}));
 
 		assert_noop!(
-			Esg::register_an_oracle(RuntimeOrigin::root(), NON_SUDO_ORACLE, false),
+			Esg::register_an_oracle(RuntimeOrigin::root(), addr.NON_SUDO_ORACLE, false),
 			Error::<Test>::OracleRegisteredAlready
 		);
 	});
@@ -161,34 +198,36 @@ fn it_must_fail_to_register_existent_oracle_again() {
 #[test]
 fn it_must_not_register_oracles_with_non_sudo_oracle_non_root_or_unsigned_origins() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		System::set_block_number(1);
 		// expect `NotSigned` error
 		assert_noop!(
-			Esg::register_an_oracle(RuntimeOrigin::none(), ALICE, true),
+			Esg::register_an_oracle(RuntimeOrigin::none(), addr.ALICE, true),
 			Error::<Test>::NotSigned
 		);
 
 		// expect `CallerNotRootOrSudoOracle` error
 		assert_noop!(
-			Esg::register_an_oracle(RuntimeOrigin::signed(ALICE), ALICE, true),
+			Esg::register_an_oracle(RuntimeOrigin::signed(addr.ALICE), addr.ALICE, true),
 			Error::<Test>::CallerNotRootOrSudoOracle
 		);
 
 		// expect `CallerNotRootOrSudoOracle` error
 		assert_noop!(
-			Esg::register_an_oracle(RuntimeOrigin::signed(ALICE), ALICE, false),
+			Esg::register_an_oracle(RuntimeOrigin::signed(addr.ALICE), addr.ALICE, false),
 			Error::<Test>::CallerNotRootOrSudoOracle
 		);
 
 		// expect `CallerNotRootOrSudoOracle` error
 		assert_noop!(
-			Esg::register_an_oracle(RuntimeOrigin::signed(ALICE), DUMMY_SUDO_ORACLE, true),
+			Esg::register_an_oracle(RuntimeOrigin::signed(addr.ALICE), addr.DUMMY_SUDO_ORACLE, true),
 			Error::<Test>::CallerNotRootOrSudoOracle
 		);
 
 		// expect `CallerNotRootOrSudoOracle` error
 		assert_noop!(
-			Esg::register_an_oracle(RuntimeOrigin::signed(ALICE), DUMMY_SUDO_ORACLE, false),
+			Esg::register_an_oracle(RuntimeOrigin::signed(addr.ALICE), addr.DUMMY_SUDO_ORACLE, false),
 			Error::<Test>::CallerNotRootOrSudoOracle
 		);
 	});
@@ -197,31 +236,33 @@ fn it_must_not_register_oracles_with_non_sudo_oracle_non_root_or_unsigned_origin
 #[test]
 fn it_must_deregister_oracles_with_root_only() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		// -------------- deregistering sudo oracles ---------------
 
 		System::set_block_number(1);
 
 		// registering a sudo oracle with root
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// Check sudo oracle added
-		assert!(Esg::get_oracle_sudo().contains(&SUDO_ORACLE));
+		assert!(Esg::get_oracle_sudo().contains(&addr.SUDO_ORACLE));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
-		assert_ok!(Esg::deregister_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::deregister_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// Check sudo oracle removed
-		assert!(!Esg::get_oracle_sudo().contains(&SUDO_ORACLE));
+		assert!(!Esg::get_oracle_sudo().contains(&addr.SUDO_ORACLE));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::OracleDeRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
 		// lets check for non-root signed txn
@@ -229,17 +270,17 @@ fn it_must_deregister_oracles_with_root_only() {
 		System::set_block_number(1);
 
 		// registering a sudo oracle with root
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
 		// expect `BadOrigin` error
 		assert_noop!(
-			Esg::deregister_an_oracle(RuntimeOrigin::signed(ALICE), SUDO_ORACLE, true),
+			Esg::deregister_an_oracle(RuntimeOrigin::signed(addr.ALICE), addr.SUDO_ORACLE, true),
 			DispatchError::BadOrigin
 		);
 
@@ -248,21 +289,21 @@ fn it_must_deregister_oracles_with_root_only() {
 		System::set_block_number(1);
 
 		// registering a non-sudo oracle with root
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), NON_SUDO_ORACLE, false));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.NON_SUDO_ORACLE, false));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: false,
-			oracle: NON_SUDO_ORACLE,
+			oracle: addr.NON_SUDO_ORACLE,
 		}));
 
 		// deregistering a non-sudo oracle with root
-		assert_ok!(Esg::deregister_an_oracle(RuntimeOrigin::root(), NON_SUDO_ORACLE, false));
+		assert_ok!(Esg::deregister_an_oracle(RuntimeOrigin::root(), addr.NON_SUDO_ORACLE, false));
 
 		// check `OracleDeRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::OracleDeRegistered {
 			is_sudo: false,
-			oracle: NON_SUDO_ORACLE,
+			oracle: addr.NON_SUDO_ORACLE,
 		}));
 	});
 }
@@ -270,31 +311,33 @@ fn it_must_deregister_oracles_with_root_only() {
 #[test]
 fn it_must_fail_to_deregister_nonexistent_oracle() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		// -------------- deregistering sudo oracles ---------------
 
 		System::set_block_number(1);
 
 		// registering a sudo oracle with root
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// Check sudo oracle added
-		assert!(Esg::get_oracle_sudo().contains(&SUDO_ORACLE));
+		assert!(Esg::get_oracle_sudo().contains(&addr.SUDO_ORACLE));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
-		assert_ok!(Esg::deregister_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::deregister_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// Check sudo oracle removed
-		assert!(!Esg::get_oracle_sudo().contains(&SUDO_ORACLE));
+		assert!(!Esg::get_oracle_sudo().contains(&addr.SUDO_ORACLE));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::OracleDeRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
 		// lets check for non-root signed txn
@@ -303,7 +346,7 @@ fn it_must_fail_to_deregister_nonexistent_oracle() {
 
 		// try deregistering the oracle which doesn't exist
 		assert_noop!(
-			Esg::deregister_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true),
+			Esg::deregister_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true),
 			Error::<Test>::OracleNotExist
 		);
 	});
@@ -313,21 +356,23 @@ fn it_must_fail_to_deregister_nonexistent_oracle() {
 
 fn it_must_not_allow_upload_from_a_non_oracle() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		let data = r#"[
 			{
 				"score":"3599760637",
-				"account":"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+				"account":"0x82a0EcfDd3174bEF5D5eA452e15219A52bf6161f"
 			},
 			{
 				"score":"447537718",
-				"account":"5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+				"account":"0xBa08C49f377a4F01c65340F431B5C65D71B972a9"
 			}
 		]"#;
 
 		// expect `CallerNotAnOracle` error
 		assert_noop!(
 			Esg::upsert_esg_scores(
-				RuntimeOrigin::signed(ALICE),
+				RuntimeOrigin::signed(addr.ALICE),
 				(WeakBoundedVec::try_from(data.as_bytes().to_vec())).unwrap()
 			),
 			Error::<Test>::CallerNotAnOracle
@@ -338,27 +383,29 @@ fn it_must_not_allow_upload_from_a_non_oracle() {
 #[test]
 fn it_must_not_accept_wrongly_formatted_input() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		System::set_block_number(1);
 		let complete_invalid_data = r#"@01234abcd"#;
 
 		let non_array_data = r#"
 			{
 				"score":"3599760637",
-				"account":"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+				"account":"0x82a0EcfDd3174bEF5D5eA452e15219A52bf6161f"
 			},
 			{
 				"score":"447537718",
-				"account":"5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+				"account":"0xBa08C49f377a4F01c65340F431B5C65D71B972a9"
 			}"#;
 
 		let data_with_quotes_missing = r#"[
 			{
 				"score":"3599760637",
-				account":"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+				account":"0x82a0EcfDd3174bEF5D5eA452e15219A52bf6161f"
 			},
 			{
 				"score":"447537718",
-				"account":"5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+				"account":"0xBa08C49f377a4F01c65340F431B5C65D71B972a9"
 			}
 		]"#;
 
@@ -369,22 +416,22 @@ fn it_must_not_accept_wrongly_formatted_input() {
 			},
 			{
 				"score":"447537718",
-				"account":"5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+				"account":"0xBa08C49f377a4F01c65340F431B5C65D71B972a9"
 			}
 		]"#;
 
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
 		// expect `InvalidJson` error
 		assert_noop!(
 			Esg::upsert_esg_scores(
-				RuntimeOrigin::signed(SUDO_ORACLE),
+				RuntimeOrigin::signed(addr.SUDO_ORACLE),
 				(WeakBoundedVec::try_from(complete_invalid_data.as_bytes().to_vec())).unwrap()
 			),
 			Error::<Test>::InvalidJson
@@ -393,7 +440,7 @@ fn it_must_not_accept_wrongly_formatted_input() {
 		// expect `InvalidJson` error
 		assert_noop!(
 			Esg::upsert_esg_scores(
-				RuntimeOrigin::signed(SUDO_ORACLE),
+				RuntimeOrigin::signed(addr.SUDO_ORACLE),
 				(WeakBoundedVec::try_from(non_array_data.as_bytes().to_vec())).unwrap()
 			),
 			Error::<Test>::InvalidJson
@@ -402,7 +449,7 @@ fn it_must_not_accept_wrongly_formatted_input() {
 		// expect `InvalidJson` error
 		assert_noop!(
 			Esg::upsert_esg_scores(
-				RuntimeOrigin::signed(SUDO_ORACLE),
+				RuntimeOrigin::signed(addr.SUDO_ORACLE),
 				(WeakBoundedVec::try_from(data_with_quotes_missing.as_bytes().to_vec())).unwrap()
 			),
 			Error::<Test>::InvalidJson
@@ -411,7 +458,7 @@ fn it_must_not_accept_wrongly_formatted_input() {
 		// expect `InvalidJson` error
 		assert_noop!(
 			Esg::upsert_esg_scores(
-				RuntimeOrigin::signed(SUDO_ORACLE),
+				RuntimeOrigin::signed(addr.SUDO_ORACLE),
 				(WeakBoundedVec::try_from(data_with_broken_key_value.as_bytes().to_vec())).unwrap()
 			),
 			Error::<Test>::InvalidJson
@@ -422,52 +469,54 @@ fn it_must_not_accept_wrongly_formatted_input() {
 #[test]
 fn it_must_upload_all_valid_esg_data_with_no_skipping() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		// to generate an event data
 		System::set_block_number(1);
 		let data = r#"[
 			{
 				"score":"12",
-				"account":"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+				"account":"0x82a0EcfDd3174bEF5D5eA452e15219A52bf6161f"
 			},
 			{
 				"score":"40",
-				"account":"5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+				"account":"0xBa08C49f377a4F01c65340F431B5C65D71B972a9"
 			}
 		]"#;
 
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		assert_ok!(Esg::upsert_esg_scores(
-			RuntimeOrigin::signed(SUDO_ORACLE),
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
 			(WeakBoundedVec::try_from(data.as_bytes().to_vec())).unwrap()
 		));
 
-		let company1 =
-			AccountId32::from_str("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty").unwrap();
-		let company2 =
-			AccountId32::from_str("5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy").unwrap();
+		let company1 = Esg::hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
+		let company2 = Esg::hexstr2acc_id20("Ba08C49f377a4F01c65340F431B5C65D71B972a9");
 
 		assert_eq!(Esg::get_score_of(company1), 12);
 		assert_eq!(Esg::get_score_of(company2), 40);
 
 		// event `ESGStored` must have got triggered with expected data
-		System::assert_last_event(RuntimeEvent::Esg(crate::Event::ESGStored { caller: ROOT }));
+		System::assert_last_event(RuntimeEvent::Esg(crate::Event::ESGStored { caller: addr.ROOT }));
 	});
 }
 
 #[test]
 fn it_must_skip_for_invalid_addresses_in_esg_data() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		System::set_block_number(1);
 		// invalid addresses at indexes 0, 2, 3, 5
 		let wrong_address_data = r#"[
 			{
 				"score":"3599760637",
-				"account":"5DA&nrj7VHTznn!AWBemMuyBwZWs6FNF@dyVXUeYum3PTXFy"
+				"account":"0x82a0EcfDd3174bEF5D5eA452e15219A52bf6161f"
 			},
 			{
 				"score":"3599760637",
-				"account":"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+				"account":"0xBa08C49f377a4F01c65340F431B5C65D71B972a"
 			},
 			{
 				"score":"3599760637",
@@ -479,7 +528,7 @@ fn it_must_skip_for_invalid_addresses_in_esg_data() {
 			},
 			{
 				"score":"99",
-				"account":"5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+				"account":"0x25Db9D98e4Ab6af68ac7173f580c444155B7b5C8"
 			},
 			{
 				"score":"3599760637",
@@ -487,31 +536,29 @@ fn it_must_skip_for_invalid_addresses_in_esg_data() {
 			}
 		]"#;
 		// register sudo as an oracle
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
 		assert_ok!(Esg::upsert_esg_scores(
-			RuntimeOrigin::signed(SUDO_ORACLE),
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
 			(WeakBoundedVec::try_from(wrong_address_data.as_bytes().to_vec())).unwrap()
 		));
 
-		let valid_id1 =
-			AccountId32::from_str("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty").unwrap();
-		let valid_id2 =
-			AccountId32::from_str("5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy").unwrap();
+		let valid_id1 = Esg::hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
+		let valid_id2 = Esg::hexstr2acc_id20("25Db9D98e4Ab6af68ac7173f580c444155B7b5C8");
 
-		assert_eq!(Esg::get_score_of(valid_id1), 100);
+		assert_eq!(Esg::get_score_of(valid_id1), MAX_ESG_SCORE);
 		assert_eq!(Esg::get_score_of(valid_id2), 99);
 
 		// check `ESGStoredWithSkip` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::ESGStoredWithSkip {
-			caller: SUDO_ORACLE,
-			skipped_indeces: vec![0, 2, 3, 5],
+			caller: addr.SUDO_ORACLE,
+			skipped_indeces: vec![1, 2, 3, 5],
 		}));
 	});
 }
@@ -519,43 +566,42 @@ fn it_must_skip_for_invalid_addresses_in_esg_data() {
 #[test]
 fn it_must_handle_invalid_esg_scores() {
 	new_test_ext().execute_with(|| {
+		let addr = Addr::default();
+
 		System::set_block_number(1);
 		let esg_data_with_invalid_scores = r#"[
 			{
 				"score":"-1",
-				"account":"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+				"account":"0x82a0EcfDd3174bEF5D5eA452e15219A52bf6161f"
 			},
 			{
 				"score":"ab@",
-				"account":"5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+				"account":"0xBa08C49f377a4F01c65340F431B5C65D71B972a9"
 			},
 			{
 				"score": "",
-				"account": "5FhTgr75zm6QC4ohRHKFcaaMVnjifTaRcaYeGKBPBBbSSBtK"
+				"account": "0x25Db9D98e4Ab6af68ac7173f580c444155B7b5C8"
 			}
 		]"#;
 
 		// register sudo as an oracle
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
 		// upload the scores
 		assert_ok!(Esg::upsert_esg_scores(
-			RuntimeOrigin::signed(SUDO_ORACLE),
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
 			(WeakBoundedVec::try_from(esg_data_with_invalid_scores.as_bytes().to_vec())).unwrap()
 		));
 
-		let company1 =
-			AccountId32::from_str("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty").unwrap();
-		let company2 =
-			AccountId32::from_str("5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy").unwrap();
-		let company3 =
-			AccountId32::from_str("5FhTgr75zm6QC4ohRHKFcaaMVnjifTaRcaYeGKBPBBbSSBtK").unwrap();
+		let company1 = Esg::hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
+		let company2 = Esg::hexstr2acc_id20("Ba08C49f377a4F01c65340F431B5C65D71B972a9");
+		let company3 = Esg::hexstr2acc_id20("25Db9D98e4Ab6af68ac7173f580c444155B7b5C8");
 
 		// negative to zero
 		assert_eq!(Esg::get_score_of(company1), 0);
@@ -566,45 +612,45 @@ fn it_must_handle_invalid_esg_scores() {
 
 		// check `ESGStored` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::ESGStored {
-			caller: SUDO_ORACLE,
+			caller: addr.SUDO_ORACLE,
 		}));
 	});
 }
 
 #[test]
 fn it_must_handle_scores_exceeding_set_maximum() {
+	let addr = Addr::default();
+
 	new_test_ext().execute_with(|| {
 		System::set_block_number(1);
 		let data = r#"[
 			{
 				"score":"121",
-				"account":"5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+				"account":"0x82a0EcfDd3174bEF5D5eA452e15219A52bf6161f"
 			},
 			{
 				"score":"7675675",
-				"account":"5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+				"account":"0xBa08C49f377a4F01c65340F431B5C65D71B972a9"
 			}
 		]"#;
 
 		// register sudo as an oracle
-		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), SUDO_ORACLE, true));
+		assert_ok!(Esg::register_an_oracle(RuntimeOrigin::root(), addr.SUDO_ORACLE, true));
 
 		// check `NewOracleRegistered` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::NewOracleRegistered {
 			is_sudo: true,
-			oracle: SUDO_ORACLE,
+			oracle: addr.SUDO_ORACLE,
 		}));
 
 		// upload the scores
 		assert_ok!(Esg::upsert_esg_scores(
-			RuntimeOrigin::signed(SUDO_ORACLE),
+			RuntimeOrigin::signed(addr.SUDO_ORACLE),
 			(WeakBoundedVec::try_from(data.as_bytes().to_vec())).unwrap()
 		));
 
-		let company1 =
-			AccountId32::from_str("5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty").unwrap();
-		let company2 =
-			AccountId32::from_str("5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy").unwrap();
+		let company1 = Esg::hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
+		let company2 = Esg::hexstr2acc_id20("Ba08C49f377a4F01c65340F431B5C65D71B972a9");
 
 		// 121 truncated to MAX_ESG_SCORE because it exceeds MAX_ESG_SCORE
 		assert_eq!(Esg::get_score_of(company1), MAX_ESG_SCORE);
@@ -613,7 +659,7 @@ fn it_must_handle_scores_exceeding_set_maximum() {
 
 		// check `ESGStored` was trigered with expected data
 		System::assert_last_event(RuntimeEvent::Esg(crate::Event::ESGStored {
-			caller: SUDO_ORACLE,
+			caller: addr.SUDO_ORACLE,
 		}));
 	});
 }

--- a/frame/esg/src/tests.rs
+++ b/frame/esg/src/tests.rs
@@ -491,8 +491,8 @@ fn it_must_upload_all_valid_esg_data_with_no_skipping() {
 			(WeakBoundedVec::try_from(data.as_bytes().to_vec())).unwrap()
 		));
 
-		let company1 = Esg::hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
-		let company2 = Esg::hexstr2acc_id20("Ba08C49f377a4F01c65340F431B5C65D71B972a9");
+		let company1 = hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
+		let company2 = hexstr2acc_id20("Ba08C49f377a4F01c65340F431B5C65D71B972a9");
 
 		assert_eq!(Esg::get_score_of(company1), 12);
 		assert_eq!(Esg::get_score_of(company2), 40);
@@ -549,8 +549,8 @@ fn it_must_skip_for_invalid_addresses_in_esg_data() {
 			(WeakBoundedVec::try_from(wrong_address_data.as_bytes().to_vec())).unwrap()
 		));
 
-		let valid_id1 = Esg::hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
-		let valid_id2 = Esg::hexstr2acc_id20("25Db9D98e4Ab6af68ac7173f580c444155B7b5C8");
+		let valid_id1 = hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
+		let valid_id2 = hexstr2acc_id20("25Db9D98e4Ab6af68ac7173f580c444155B7b5C8");
 
 		assert_eq!(Esg::get_score_of(valid_id1), MAX_ESG_SCORE);
 		assert_eq!(Esg::get_score_of(valid_id2), 99);
@@ -599,9 +599,9 @@ fn it_must_handle_invalid_esg_scores() {
 			(WeakBoundedVec::try_from(esg_data_with_invalid_scores.as_bytes().to_vec())).unwrap()
 		));
 
-		let company1 = Esg::hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
-		let company2 = Esg::hexstr2acc_id20("Ba08C49f377a4F01c65340F431B5C65D71B972a9");
-		let company3 = Esg::hexstr2acc_id20("25Db9D98e4Ab6af68ac7173f580c444155B7b5C8");
+		let company1 = hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
+		let company2 = hexstr2acc_id20("Ba08C49f377a4F01c65340F431B5C65D71B972a9");
+		let company3 = hexstr2acc_id20("25Db9D98e4Ab6af68ac7173f580c444155B7b5C8");
 
 		// negative to zero
 		assert_eq!(Esg::get_score_of(company1), 0);
@@ -649,8 +649,8 @@ fn it_must_handle_scores_exceeding_set_maximum() {
 			(WeakBoundedVec::try_from(data.as_bytes().to_vec())).unwrap()
 		));
 
-		let company1 = Esg::hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
-		let company2 = Esg::hexstr2acc_id20("Ba08C49f377a4F01c65340F431B5C65D71B972a9");
+		let company1 = hexstr2acc_id20("82a0EcfDd3174bEF5D5eA452e15219A52bf6161f");
+		let company2 = hexstr2acc_id20("Ba08C49f377a4F01c65340F431B5C65D71B972a9");
 
 		// 121 truncated to MAX_ESG_SCORE because it exceeds MAX_ESG_SCORE
 		assert_eq!(Esg::get_score_of(company1), MAX_ESG_SCORE);

--- a/runtime/firechain-qa-runtime/Cargo.toml
+++ b/runtime/firechain-qa-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firechain-qa-runtime"
-version = "1.0.5"
+version = "1.0.6"
 authors = ["5ire Team <support@5ire.org>"]
 description = "5ire chain qa runtime"
 edition = "2021"

--- a/runtime/firechain-qa-runtime/src/lib.rs
+++ b/runtime/firechain-qa-runtime/src/lib.rs
@@ -162,7 +162,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 105,
+	spec_version: 106,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
Summary:
This pull request addresses a significant change in the `esg` pallet by replacing `AccountId32` with `AccountId20` to align with the unified address scheme.
Details:

	Replaced `AccountId32` with `AccountId20` in `esg/src/lib.rs`.
	Updated relevant functions to support `AccountId20`.
Impact:

	This change may affect existing integrations relying on `AccountId32` within the esg pallet, for instance the staking pallet.
	Marked as a breaking change (!) to alert developers.
Testing:

        All the test cases have been updated to reflect the new changes.
Review Notes:

	Verify the consistency and correctness of the changes.
	Check for any potential impact areas.
Acknowledgments:

	This change is part of the effort to adopt a unified address scheme.